### PR TITLE
独立分支，仅测试通过win qq，live.py：修改 send_qq.py 和 config.json（仅供查看，不合并该pr）

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,16 +1,33 @@
 {
-    "bot":{
-        "sessdata":"", 
-        "uid":"",
-        "handle_list": ["测试", "test", "BOT"],
-        "at_all":false
-    },
-    "live":{
-        "sessdata":"", 
-        "room_display_id":"",
-        "handle_list": ["测试", "test", "BOT"],
-        "at_all":false
-    },
-    "ntqq":false,
-    "sleep_time":2
+  "bot": {
+    "sessdata": "",
+    "uid": "",
+    "handle_list": ["测试", "test", "BOT"],
+    "class_list": ["TXGuiFoundation", "Chrome_WidgetWin_1"],
+    "_comment": "该独立分支暂不考虑bot和at_all，下播默认-a参数也不会发送下播通知",
+    "at_all": false,
+        
+    "sleep_config": {
+      "window_activate": 0.2,
+      "paste": 0.2,
+      "enter": 0.2,
+      "loop": 1
+    }
+  },
+  "live": {
+    "sessdata": "",
+    "room_display_id": "",
+    "handle_list": ["测试", "test", "BOT"],
+    "class_list": ["TXGuiFoundation", "Chrome_WidgetWin_1"],
+    "_comment": "类名，用于不同环境匹配",
+    "at_all": false,
+        
+    "sleep_config": {
+      "_comment": "window_activate：激活窗口的延迟（秒）paste：粘贴文本或图片的延迟（秒）enter：按回车发送的延迟（秒）loop：循环间隔延迟（秒）",
+      "window_activate": 0.1,
+      "paste": 0.2,
+      "enter": 0.1,
+      "loop": 1
+    }
+  }
 }

--- a/config.json
+++ b/config.json
@@ -4,10 +4,11 @@
     "uid": "",
     "handle_list": ["测试", "test", "BOT"],
     "class_list": ["TXGuiFoundation", "Chrome_WidgetWin_1"],
-    "_comment": "该独立分支暂不考虑bot和at_all，下播默认-a参数也不会发送下播通知",
+    "_comment": "仅测试通过live，bot和at_all并不考虑",
     "at_all": false,
-        
+    "use_switch": false,
     "sleep_config": {
+      "_comment": "window_activate：激活窗口的延迟（秒）paste：粘贴文本或图片的延迟（秒）enter：按回车发送的延迟（秒）loop：循环间隔延迟（秒）",
       "window_activate": 0.2,
       "paste": 0.2,
       "enter": 0.2,
@@ -19,14 +20,14 @@
     "room_display_id": "",
     "handle_list": ["测试", "test", "BOT"],
     "class_list": ["TXGuiFoundation", "Chrome_WidgetWin_1"],
-    "_comment": "类名，用于不同环境匹配",
+    "_comment": "类名，用于不同环境的兼容",
     "at_all": false,
-        
+    "use_switch": false,
     "sleep_config": {
       "_comment": "window_activate：激活窗口的延迟（秒）paste：粘贴文本或图片的延迟（秒）enter：按回车发送的延迟（秒）loop：循环间隔延迟（秒）",
-      "window_activate": 0.1,
+      "window_activate": 0.2,
       "paste": 0.2,
-      "enter": 0.1,
+      "enter": 0.2,
       "loop": 1
     }
   }

--- a/send_qq.py
+++ b/send_qq.py
@@ -1,8 +1,7 @@
 import argparse
 import json
-import io
 import os
-import glob
+import io
 import time
 import requests
 import win32gui
@@ -12,39 +11,43 @@ import win32api
 from PIL import Image
 import re
 import logging
+import glob
 
 # ------------------ Logger ------------------
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger("send_qq")
 
 # ------------------ 命令行参数 ------------------
-parser = argparse.ArgumentParser(description='发送消息到QQ窗口')
-parser.add_argument('-t', '--text', required=True, help='发送的文本内容')
-parser.add_argument('-p', '--pic', default=None, help='图片URL或本地路径')
-parser.add_argument('-c', '--config_type', default='live', choices=['bot','live'], help='配置段')
-parser.add_argument('--mode', choices=['start','stop'], default='start', help='开播/下播模式')
+parser = argparse.ArgumentParser(description="发送消息到QQ窗口")
+parser.add_argument('-t', '--text', required=True, help="发送的文本内容")
+parser.add_argument('-p', '--pic', default=None, help="图片URL")
+parser.add_argument('-c', '--config_type', default="live", choices=["bot","live"], help="配置段：bot/live")
+parser.add_argument('-a', '--at_all', type=int, choices=[0, 1], help="是否@全体成员 (0:否, 1:是)", default=None)
+parser.add_argument('--dry-run', action='store_true', help="只调试不实际发送")
 args = parser.parse_args()
 
-# ------------------ 配置文件读取 ------------------
+# ------------------ 配置读取 ------------------
 with open("config.json", "r", encoding="utf-8") as f:
     config = json.load(f)
 
 cfg = config[args.config_type]
 handle_list = cfg.get("handle_list", [])
-class_list = cfg.get("class_list", [])
-sleep_config = cfg.get("sleep_config", {"window_activate":0.2,"paste":0.2,"enter":0.2,"loop":1})
 config_at_all = bool(cfg.get("at_all", False))
+use_setforeground = bool(cfg.get("use_setforeground", True))  # 旧版QQ前台激活可选
 
-# ------------------ 决定最终 @全体 ------------------
-final_at_all = config_at_all
-logger.info(f"使用配置文件 @全体设置: {final_at_all}")
-logger.info(f"匹配窗口列表: {handle_list}, 类名: {class_list}, @所有人: {final_at_all}")
+if args.at_all is not None:
+    final_at_all = bool(args.at_all)
+else:
+    final_at_all = config_at_all
+
+logger.info(f"匹配窗口列表: {handle_list}, @所有人: {final_at_all}, 旧版QQ SetForegroundWindow: {use_setforeground}")
 
 # ------------------ 文本解析 ------------------
 def decode_unicode_escapes(text):
     text = re.sub(r'\\u([0-9a-fA-F]{4})', lambda m: chr(int(m.group(1),16)), text)
     text = text.replace("\\n", "\n")
-    return text.strip('"')
+    text = text.strip('"')
+    return text
 
 text = decode_unicode_escapes(args.text)
 logger.info(f"最终发送文本:\n{text}")
@@ -53,23 +56,96 @@ logger.info(f"最终发送文本:\n{text}")
 filename = None
 if args.pic:
     try:
-        if args.pic.startswith("http"):
-            url_filename = args.pic.split("/")[-1]
-            if not url_filename.lower().endswith('.jpg'):
-                url_filename += ".jpg"
-            response = requests.get(args.pic, stream=True)
-            response.raise_for_status()
-            filename = url_filename
-            with open(filename,'wb') as f:
-                for chunk in response.iter_content(8192):
-                    f.write(chunk)
-            logger.info(f"图片下载成功: {filename}")
-        else:
-            filename = args.pic  # 本地路径
-            logger.info(f"使用本地图片: {filename}")
+        url_filename = args.pic.split("/")[-1]
+        if not url_filename.lower().endswith(".jpg"):
+            url_filename += ".jpg"
+        response = requests.get(args.pic, stream=True)
+        response.raise_for_status()
+        filename = url_filename
+        with open(filename, "wb") as f:
+            for chunk in response.iter_content(8192):
+                f.write(chunk)
+        logger.info(f"图片下载成功: {filename}")
     except Exception as e:
-        logger.error(f"图片获取失败: {e}")
+        logger.error(f"图片下载失败: {e}")
         filename = None
+
+# ------------------ 窗口匹配 ------------------
+def enum_windows_callback(hwnd, hwnds):
+    if win32gui.IsWindowVisible(hwnd):
+        title = win32gui.GetWindowText(hwnd)
+        cls = win32gui.GetClassName(hwnd)
+        hwnds.append((hwnd, title, cls))
+
+def find_target_windows(target_names):
+    hwnds = []
+    win32gui.EnumWindows(enum_windows_callback, hwnds)
+    matched = []
+    for hwnd, title, cls in hwnds:
+        if cls not in ["TXGuiFoundation", "Chrome_WidgetWin_1"]:
+            continue
+        for name in target_names:
+            if name in title:
+                matched.append((hwnd, title, cls))
+                break
+    return matched
+
+matched_windows = find_target_windows(handle_list)
+if not matched_windows:
+    logger.error("没有找到匹配的QQ聊天窗口")
+    exit(1)
+logger.info(f"找到 {len(matched_windows)} 个匹配窗口")
+
+# ------------------ 激活窗口 ------------------
+def activate_window(hwnd, cls, use_setforeground=True):
+    try:
+        win32gui.ShowWindow(hwnd, win32con.SW_RESTORE)
+        if cls == "Chrome_WidgetWin_1":
+            # QQNT 强制前台
+            win32gui.SetForegroundWindow(hwnd)
+        elif cls == "TXGuiFoundation" and use_setforeground:
+            # 旧版QQ可选前台
+            win32gui.SetForegroundWindow(hwnd)
+        time.sleep(0.2)
+        return True
+    except Exception as e:
+        logger.error(f"窗口激活失败: {e}")
+        return False
+
+# ------------------ 粘贴和发送 ------------------
+def paste_text(hwnd, text):
+    win32clipboard.OpenClipboard()
+    win32clipboard.EmptyClipboard()
+    win32clipboard.SetClipboardData(win32con.CF_UNICODETEXT, text)
+    win32clipboard.CloseClipboard()
+    win32api.keybd_event(win32con.VK_CONTROL, 0, 0, 0)
+    win32api.keybd_event(0x56, 0, 0, 0)
+    win32api.keybd_event(0x56, 0, win32con.KEYEVENTF_KEYUP, 0)
+    win32api.keybd_event(win32con.VK_CONTROL, 0, win32con.KEYEVENTF_KEYUP, 0)
+    time.sleep(0.2)
+
+def paste_image(hwnd, filename):
+    try:
+        image = Image.open(filename)
+        output = io.BytesIO()
+        image.convert("RGB").save(output, "BMP")
+        data = output.getvalue()[14:]
+        win32clipboard.OpenClipboard()
+        win32clipboard.EmptyClipboard()
+        win32clipboard.SetClipboardData(win32con.CF_DIB, data)
+        win32clipboard.CloseClipboard()
+        win32api.keybd_event(win32con.VK_CONTROL, 0, 0, 0)
+        win32api.keybd_event(0x56, 0, 0, 0)
+        win32api.keybd_event(0x56, 0, win32con.KEYEVENTF_KEYUP, 0)
+        win32api.keybd_event(win32con.VK_CONTROL, 0, win32con.KEYEVENTF_KEYUP, 0)
+        time.sleep(0.2)
+    except Exception as e:
+        logger.error(f"图片处理失败: {e}")
+
+def send_enter(hwnd):
+    win32api.keybd_event(win32con.VK_RETURN, 0, 0, 0)
+    win32api.keybd_event(win32con.VK_RETURN, 0, win32con.KEYEVENTF_KEYUP, 0)
+    time.sleep(0.1)
 
 # ------------------ 清理旧图片 ------------------
 def cleanup_old_images(keep_filename=None):
@@ -80,94 +156,34 @@ def cleanup_old_images(keep_filename=None):
         try:
             os.remove(file)
             logger.info(f"已清理旧图片: {file}")
-        except Exception as e:
-            logger.error(f"清理图片 {file} 失败: {e}")
-
-# ------------------ 窗口匹配 ------------------
-def enum_windows_callback(hwnd, hwnds):
-    if win32gui.IsWindowVisible(hwnd):
-        title = win32gui.GetWindowText(hwnd)
-        cls = win32gui.GetClassName(hwnd)
-        hwnds.append((hwnd, title, cls))
-
-def find_target_windows(target_names, class_names):
-    hwnds = []
-    win32gui.EnumWindows(enum_windows_callback, hwnds)
-    matched = []
-    for hwnd, title, cls in hwnds:
-        if cls not in class_names:
-            continue
-        for name in target_names:
-            if name in title:
-                matched.append((hwnd, title, cls))
-                break
-    return matched
-
-matched_windows = find_target_windows(handle_list, class_list)
-if not matched_windows:
-    logger.error("没有找到匹配的QQ聊天窗口")
-    exit(1)
-logger.info(f"找到 {len(matched_windows)} 个匹配窗口")
-
-# ------------------ 前台发送 ------------------
-def activate_window(hwnd):
-    win32gui.ShowWindow(hwnd, win32con.SW_SHOWNORMAL)
-    win32gui.SetForegroundWindow(hwnd)
-    time.sleep(sleep_config["window_activate"])
-
-def paste_text(hwnd, text):
-    win32clipboard.OpenClipboard()
-    win32clipboard.EmptyClipboard()
-    win32clipboard.SetClipboardData(win32con.CF_UNICODETEXT, text)
-    win32clipboard.CloseClipboard()
-    activate_window(hwnd)
-    win32api.keybd_event(win32con.VK_CONTROL,0,0,0)
-    win32api.keybd_event(ord('V'),0,0,0)
-    win32api.keybd_event(ord('V'),0,win32con.KEYEVENTF_KEYUP,0)
-    win32api.keybd_event(win32con.VK_CONTROL,0,win32con.KEYEVENTF_KEYUP,0)
-    time.sleep(sleep_config["paste"])
-
-def paste_image(hwnd, filename):
-    try:
-        image = Image.open(filename)
-        output = io.BytesIO()
-        image.convert("RGB").save(output,"BMP")
-        data = output.getvalue()[14:]
-        win32clipboard.OpenClipboard()
-        win32clipboard.EmptyClipboard()
-        win32clipboard.SetClipboardData(win32con.CF_DIB,data)
-        win32clipboard.CloseClipboard()
-        activate_window(hwnd)
-        win32api.keybd_event(win32con.VK_CONTROL,0,0,0)
-        win32api.keybd_event(ord('V'),0,0,0)
-        win32api.keybd_event(ord('V'),0,win32con.KEYEVENTF_KEYUP,0)
-        win32api.keybd_event(win32con.VK_CONTROL,0,win32con.KEYEVENTF_KEYUP,0)
-        time.sleep(sleep_config["paste"])
-    except Exception as e:
-        logger.error(f"图片处理失败: {e}")
-
-def send_enter(hwnd):
-    activate_window(hwnd)
-    win32api.keybd_event(win32con.VK_RETURN,0,0,0)
-    win32api.keybd_event(win32con.VK_RETURN,0,win32con.KEYEVENTF_KEYUP,0)
-    time.sleep(sleep_config["enter"])
+        except:
+            pass
 
 # ------------------ 主流程 ------------------
 try:
     for hwnd, title, cls in matched_windows:
-        logger.info(f"处理窗口: {title} (类名: {cls}, 句柄: {hwnd})")
+        logger.info(f"处理窗口: {title} (句柄: {hwnd}, 类名: {cls})")
+
+        if not activate_window(hwnd, cls, use_setforeground):
+            logger.error("窗口激活失败，跳过此窗口")
+            continue
+
         if final_at_all:
             paste_text(hwnd, "@所有人")
             send_enter(hwnd)
+
         paste_text(hwnd, text)
+
         if filename:
             paste_image(hwnd, filename)
+
         send_enter(hwnd)
         logger.info(f"消息已发送到窗口: {title}")
-        time.sleep(sleep_config["loop"])
+
 except Exception as e:
     logger.error(f"发送过程中出现错误: {e}")
+
 finally:
     cleanup_old_images(filename)
     if filename:
-        logger.info(f"新图片 {filename} 已被保留")
+        logger.info(f"新图片 {filename} 已保留")

--- a/send_qq.py
+++ b/send_qq.py
@@ -1,214 +1,173 @@
-from time import sleep
-import requests
-import win32con
-import win32gui
-import win32clipboard
-import win32com.client
-import win32api
-from PIL import Image
+import argparse
 import json
 import io
-import sys
-import argparse
-from logger import setup_logger
-from typing import Union
+import os
+import glob
+import time
+import requests
+import win32gui
+import win32con
+import win32clipboard
+import win32api
+from PIL import Image
+import re
+import logging
 
-logger = setup_logger(filename='send_qq')
+# ------------------ Logger ------------------
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger("send_qq")
 
-def parse_args():
-    """解析命令行参数"""
-    parser = argparse.ArgumentParser(description='发送消息至qq窗口的脚本模块')
-    parser.add_argument('-p', '--pic', dest='pic_path', type=str, default=None,
-                        help='传入图片的本地路径_default=None')
-    parser.add_argument('-t', '--text', dest='text', type=str, default=None,
-                        help='传入需要发送的内容_must')
-    parser.add_argument('-a', '--at_all', dest='at_all', type=int, default=1,
-                        help='是否强制@所有人，0为强制否，其他参数代表config为最高优先级_default=1')
-    return parser.parse_args()
+# ------------------ 命令行参数 ------------------
+parser = argparse.ArgumentParser(description='发送消息到QQ窗口')
+parser.add_argument('-t', '--text', required=True, help='发送的文本内容')
+parser.add_argument('-p', '--pic', default=None, help='图片URL或本地路径')
+parser.add_argument('-c', '--config_type', default='live', choices=['bot','live'], help='配置段')
+parser.add_argument('--mode', choices=['start','stop'], default='start', help='开播/下播模式')
+args = parser.parse_args()
 
-def send_to_window_ntqq(hwnd:int, text:str, at_all=False, pic_path=None,sleep_time:Union[int,float]=2):
-    """向指定NTQQ窗口发送消息（文本 + @全体）"""
-    win32gui.ShowWindow(hwnd, win32con.SW_RESTORE)  # 恢复窗口
-    win32gui.SetForegroundWindow(hwnd)  # 确保窗口在前台
-    sleep(sleep_time)
+# ------------------ 配置文件读取 ------------------
+with open("config.json", "r", encoding="utf-8") as f:
+    config = json.load(f)
 
-    # @全体
-    if at_all:
-        win32clipboard.OpenClipboard()
-        win32clipboard.EmptyClipboard()
-        win32clipboard.SetClipboardData(win32con.CF_UNICODETEXT, "@")
-        win32clipboard.CloseClipboard()
-        win32api.keybd_event(win32con.VK_CONTROL, 0, 0, 0)  # 按下Ctrl
-        win32api.keybd_event(ord('V'), 0, 0, 0)  # 按下V
-        win32api.keybd_event(ord('V'), 0, win32con.KEYEVENTF_KEYUP, 0)  # 释放V
-        win32api.keybd_event(win32con.VK_CONTROL, 0, win32con.KEYEVENTF_KEYUP, 0)
-        sleep(sleep_time)   #等待@符号加载
-        # 按下Enter键
-        win32api.keybd_event(win32con.VK_RETURN, 0, 0, 0)
-        # 释放Enter键
-        win32api.keybd_event(win32con.VK_RETURN, 0, win32con.KEYEVENTF_KEYUP, 0)
-        sleep(sleep_time)
+cfg = config[args.config_type]
+handle_list = cfg.get("handle_list", [])
+class_list = cfg.get("class_list", [])
+sleep_config = cfg.get("sleep_config", {"window_activate":0.2,"paste":0.2,"enter":0.2,"loop":1})
+config_at_all = bool(cfg.get("at_all", False))
 
-    # 文本
-    win32clipboard.OpenClipboard()
-    win32clipboard.EmptyClipboard()
-    win32clipboard.SetClipboardData(win32con.CF_UNICODETEXT, text)
-    win32clipboard.CloseClipboard()
-    sleep(sleep_time)
+# ------------------ 决定最终 @全体 ------------------
+final_at_all = config_at_all
+logger.info(f"使用配置文件 @全体设置: {final_at_all}")
+logger.info(f"匹配窗口列表: {handle_list}, 类名: {class_list}, @所有人: {final_at_all}")
 
-    win32api.keybd_event(win32con.VK_CONTROL, 0, 0, 0)  # 按下Ctrl
-    win32api.keybd_event(ord('V'), 0, 0, 0)  # 按下V
-    win32api.keybd_event(ord('V'), 0, win32con.KEYEVENTF_KEYUP, 0)  # 释放V
-    win32api.keybd_event(win32con.VK_CONTROL, 0, win32con.KEYEVENTF_KEYUP, 0)
+# ------------------ 文本解析 ------------------
+def decode_unicode_escapes(text):
+    text = re.sub(r'\\u([0-9a-fA-F]{4})', lambda m: chr(int(m.group(1),16)), text)
+    text = text.replace("\\n", "\n")
+    return text.strip('"')
 
-    # 处理图片
-    if pic_path is not None:
-        # 下载图片
-        response = requests.get(pic_path, stream=True)
-        response.raise_for_status()
-        filename = pic_path.split("/")[-1]
-        with open(filename, 'wb') as file:
-            for chunk in response.iter_content(chunk_size=8192):
-                file.write(chunk)
-        # 发送图片
-        image = Image.open(filename)
-        output = io.BytesIO()
-        image.convert("RGB").save(output, "BMP")
-        data = output.getvalue()[14:]
-        win32clipboard.OpenClipboard()
-        win32clipboard.EmptyClipboard()
-        win32clipboard.SetClipboardData(win32con.CF_DIB, data)
-        win32clipboard.CloseClipboard()
-        sleep(sleep_time)
-        win32api.keybd_event(win32con.VK_CONTROL, 0, 0, 0)  # 按下Ctrl
-        win32api.keybd_event(ord('V'), 0, 0, 0)  # 按下V
-        win32api.keybd_event(ord('V'), 0, win32con.KEYEVENTF_KEYUP, 0)  # 释放V
-        win32api.keybd_event(win32con.VK_CONTROL, 0, win32con.KEYEVENTF_KEYUP, 0)
+text = decode_unicode_escapes(args.text)
+logger.info(f"最终发送文本:\n{text}")
 
-    # 发送
-    sleep(sleep_time)
-    # 按下Enter键
-    win32api.keybd_event(win32con.VK_RETURN, 0, 0, 0)
-    # 释放Enter键
-    win32api.keybd_event(win32con.VK_RETURN, 0, win32con.KEYEVENTF_KEYUP, 0)
-    sleep(sleep_time)
-    print(f"✅ 已向窗口[{win32gui.GetWindowText(hwnd)}]发送消息")
-
-def enum_target_windows_ntqq(target_titles:list):
-    """枚举NTQQ目标窗口（严格匹配标题）"""
-    result = []
-    def callback(hwnd, extra):
-        if win32gui.IsWindowVisible(hwnd):
-            title = win32gui.GetWindowText(hwnd).strip()
-            if title in target_titles:  # 精确匹配
-                result.append(hwnd)
-        return True
-    win32gui.EnumWindows(callback, None)
-    return result
-
-def send_to_window_qq(handle:int, text:str, at_all=False, pic_path=None, sleep_time:Union[int,float]=2):
-    """向指定传统QQ窗口发送消息（文本 + @全体）"""
-    # 初始化Shell对象用于发送按键
-    shell = win32com.client.Dispatch("WScript.Shell")
-    win32gui.ShowWindow(handle, win32con.SW_RESTORE)  # 恢复窗口（如果处于最小化状态）
-    shell.SendKeys('%')  # 发送Alt键绕过Windows的前台权限限制
-    win32gui.ShowWindow(handle, win32con.SW_SHOW)  # 确保窗口显示在最前端
-    logger.info(f"找到窗口句柄: {handle}")
-    
-    if at_all:
-        # 处理@符号
-        win32clipboard.OpenClipboard()
-        win32clipboard.EmptyClipboard()
-        win32clipboard.SetClipboardData(win32con.CF_UNICODETEXT, "@")
-        win32clipboard.CloseClipboard()
-        win32gui.SendMessage(handle, 770, 0, 0)  # Ctrl+V
-        sleep(sleep_time)   # 等待@符号加载
-        win32gui.SendMessage(handle, win32con.WM_KEYDOWN, win32con.VK_RETURN, 0)
-        sleep(sleep_time)
-    
-    # 处理文本
-    win32clipboard.OpenClipboard()
-    win32clipboard.EmptyClipboard()
-    win32clipboard.SetClipboardData(win32con.CF_UNICODETEXT, text)
-    win32clipboard.CloseClipboard()
-    sleep(sleep_time)
-    win32gui.SendMessage(handle, 770, 0, 0)  # Ctrl+V
-    
-    # 处理图片
-    if pic_path is not None:
-        # 下载图片
-        response = requests.get(pic_path, stream=True)
-        response.raise_for_status()
-        filename = pic_path.split("/")[-1]
-        with open(filename, 'wb') as file:
-            for chunk in response.iter_content(chunk_size=8192):
-                file.write(chunk)
-                
-        # 发送图片
-        image = Image.open(filename)
-        output = io.BytesIO()
-        image.convert("RGB").save(output, "BMP")
-        data = output.getvalue()[14:]
-        win32clipboard.OpenClipboard()
-        win32clipboard.EmptyClipboard()
-        win32clipboard.SetClipboardData(win32con.CF_DIB, data)
-        win32clipboard.CloseClipboard()
-        sleep(sleep_time)
-        win32gui.SendMessage(handle, 770, 0, 0)  # Ctrl+V
-    
-    # 发送
-    sleep(sleep_time)
-    win32gui.SendMessage(handle, win32con.WM_KEYDOWN, win32con.VK_RETURN, 0)
-    logger.info("消息发送成功")
-    sleep(sleep_time)
-
-args = parse_args()
-pic = args.pic_path
-at_all_must = args.at_all
-# 对文本参数进行反转义处理
-if args.text:
-    # 先还原转义序列，再解码
-    text = args.text.encode('utf-8').decode('unicode_escape')
-else:
-    text = None
-
-if text is None:
-    logger.error("请使用-t参数传入需要发送的内容")
-    sys.exit(1)
-
-
-# 从配置文件中读取配置
-with open('config.json', 'r', encoding='utf-8') as config_file:
-    config = json.load(config_file)
-
-sleep_time = config.get('sleep_time')
-
-handle_list= list(config['bot']['handle_list'])
-if at_all_must == 0:
-    at_all = False
-else:
-    at_all = bool(config['bot']['at_all'])
-
-# 检查是否使用NTQQ模式
-is_ntqq = bool(config.get('ntqq', False))
-
-if is_ntqq:
-    # NTQQ模式
-    hwnds = enum_target_windows_ntqq(handle_list)
-    if not hwnds:
-        print("❌ 未找到符合条件的窗口")
-        sys.exit(1)
-    else:
-        print(f"找到 {len(hwnds)} 个目标窗口")
-        for hwnd in hwnds:
-            send_to_window_ntqq(hwnd, text, at_all, pic,sleep_time)
-else:
-    # 传统QQ模式
-    for handles in handle_list:
-        handle = win32gui.FindWindow(None, handles) # 获取窗口句柄
-        if handle != 0:  # 确保窗口存在
-            send_to_window_qq(handle, text, at_all, pic,sleep_time)
+# ------------------ 下载图片 ------------------
+filename = None
+if args.pic:
+    try:
+        if args.pic.startswith("http"):
+            url_filename = args.pic.split("/")[-1]
+            if not url_filename.lower().endswith('.jpg'):
+                url_filename += ".jpg"
+            response = requests.get(args.pic, stream=True)
+            response.raise_for_status()
+            filename = url_filename
+            with open(filename,'wb') as f:
+                for chunk in response.iter_content(8192):
+                    f.write(chunk)
+            logger.info(f"图片下载成功: {filename}")
         else:
-            logger.warning(f"未找到窗口: {handles}")
+            filename = args.pic  # 本地路径
+            logger.info(f"使用本地图片: {filename}")
+    except Exception as e:
+        logger.error(f"图片获取失败: {e}")
+        filename = None
 
-exit(0)
+# ------------------ 清理旧图片 ------------------
+def cleanup_old_images(keep_filename=None):
+    jpg_files = glob.glob("*.jpg")
+    for file in jpg_files:
+        if keep_filename and file == keep_filename:
+            continue
+        try:
+            os.remove(file)
+            logger.info(f"已清理旧图片: {file}")
+        except Exception as e:
+            logger.error(f"清理图片 {file} 失败: {e}")
+
+# ------------------ 窗口匹配 ------------------
+def enum_windows_callback(hwnd, hwnds):
+    if win32gui.IsWindowVisible(hwnd):
+        title = win32gui.GetWindowText(hwnd)
+        cls = win32gui.GetClassName(hwnd)
+        hwnds.append((hwnd, title, cls))
+
+def find_target_windows(target_names, class_names):
+    hwnds = []
+    win32gui.EnumWindows(enum_windows_callback, hwnds)
+    matched = []
+    for hwnd, title, cls in hwnds:
+        if cls not in class_names:
+            continue
+        for name in target_names:
+            if name in title:
+                matched.append((hwnd, title, cls))
+                break
+    return matched
+
+matched_windows = find_target_windows(handle_list, class_list)
+if not matched_windows:
+    logger.error("没有找到匹配的QQ聊天窗口")
+    exit(1)
+logger.info(f"找到 {len(matched_windows)} 个匹配窗口")
+
+# ------------------ 前台发送 ------------------
+def activate_window(hwnd):
+    win32gui.ShowWindow(hwnd, win32con.SW_SHOWNORMAL)
+    win32gui.SetForegroundWindow(hwnd)
+    time.sleep(sleep_config["window_activate"])
+
+def paste_text(hwnd, text):
+    win32clipboard.OpenClipboard()
+    win32clipboard.EmptyClipboard()
+    win32clipboard.SetClipboardData(win32con.CF_UNICODETEXT, text)
+    win32clipboard.CloseClipboard()
+    activate_window(hwnd)
+    win32api.keybd_event(win32con.VK_CONTROL,0,0,0)
+    win32api.keybd_event(ord('V'),0,0,0)
+    win32api.keybd_event(ord('V'),0,win32con.KEYEVENTF_KEYUP,0)
+    win32api.keybd_event(win32con.VK_CONTROL,0,win32con.KEYEVENTF_KEYUP,0)
+    time.sleep(sleep_config["paste"])
+
+def paste_image(hwnd, filename):
+    try:
+        image = Image.open(filename)
+        output = io.BytesIO()
+        image.convert("RGB").save(output,"BMP")
+        data = output.getvalue()[14:]
+        win32clipboard.OpenClipboard()
+        win32clipboard.EmptyClipboard()
+        win32clipboard.SetClipboardData(win32con.CF_DIB,data)
+        win32clipboard.CloseClipboard()
+        activate_window(hwnd)
+        win32api.keybd_event(win32con.VK_CONTROL,0,0,0)
+        win32api.keybd_event(ord('V'),0,0,0)
+        win32api.keybd_event(ord('V'),0,win32con.KEYEVENTF_KEYUP,0)
+        win32api.keybd_event(win32con.VK_CONTROL,0,win32con.KEYEVENTF_KEYUP,0)
+        time.sleep(sleep_config["paste"])
+    except Exception as e:
+        logger.error(f"图片处理失败: {e}")
+
+def send_enter(hwnd):
+    activate_window(hwnd)
+    win32api.keybd_event(win32con.VK_RETURN,0,0,0)
+    win32api.keybd_event(win32con.VK_RETURN,0,win32con.KEYEVENTF_KEYUP,0)
+    time.sleep(sleep_config["enter"])
+
+# ------------------ 主流程 ------------------
+try:
+    for hwnd, title, cls in matched_windows:
+        logger.info(f"处理窗口: {title} (类名: {cls}, 句柄: {hwnd})")
+        if final_at_all:
+            paste_text(hwnd, "@所有人")
+            send_enter(hwnd)
+        paste_text(hwnd, text)
+        if filename:
+            paste_image(hwnd, filename)
+        send_enter(hwnd)
+        logger.info(f"消息已发送到窗口: {title}")
+        time.sleep(sleep_config["loop"])
+except Exception as e:
+    logger.error(f"发送过程中出现错误: {e}")
+finally:
+    cleanup_old_images(filename)
+    if filename:
+        logger.info(f"新图片 {filename} 已被保留")


### PR DESCRIPTION
专用于win,基于原项目[bilipy_bot](https://github.com/GEYUANwuqi/bilipy_bot)修改[send_qq.py](https://github.com/GEYUANwuqi/bilipy_bot/blob/main/send_qq.py)代码，多平台兼容跨越可能性较低，不支持@所有人功能（下播默认带有-a参数，所以没有下播通知，我个人不需要），支持修改类名匹配，加上原项目中的标题，通过win32gui和SetForegroundWindow实现窗口查找与唤醒，直接叫到前台可能会觉得烦，但是这个对于qqnt版是必要的，或者窗口被最小化也能被唤醒，后台发消息仅限qq怀旧版，不能最小化窗口，这个版本也会考虑放出来，作为开播通知qq，较为稳定（有时候live.py没有轮询到或者new_live.json/old_live.json比较出现问题）