### PR TITLE
测试通过win qq，使用 live.py，修改 send_qq.py 和 config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,33 +1,23 @@
 {
     "bot": {
+        "_info": "sessdata:cookie,uid:UP主的UID,handle_list:窗口标题关键词列表, at_all:是否@所有人(全部类型)",
         "sessdata": "",
         "uid": "",
         "handle_list": ["测试", "test", "BOT"],
-        "class_list": ["TXGuiFoundation", "Chrome_WidgetWin_1"],
-        "at_all": false,
-        "sleep_config": {
-            "window_activate": 0.2,
-            "paste": 0.2,
-            "enter": 0.2,
-            "loop": 1
-        }
+        "at_all": false
     },
     "live": {
+        "_info": "sessdata:cookie,room_display_id:直播间ID,handle_list:窗口标题关键词列表, at_all:是否@所有人(仅开播通知生效)",
         "sessdata": "",
         "room_display_id": "",
-        "handle_list": [""],
-        "class_list": ["TXGuiFoundation", "Chrome_WidgetWin_1"],
-        "_comment": "标题匹配和类名，修改后捕捉对应窗口即可发送消息与图片，非qq也将可用，默认回车，请将qq发送消息改为回车发送",
-        "at_all": false,
-        "sleep_config": {
-            "_comment": "window_activate：激活窗口的延迟（秒）paste：粘贴文本或图片的延迟（秒）enter：按回车发送的延迟（秒）loop：循环间隔延迟（秒）",
-            "window_activate": 0.2,
-            "paste": 0.2,
-            "enter": 0.2,
-            "loop": 1
-        }
+        "handle_list": ["测试", "test", "BOT"],
+        "at_all": false
     },
-    "ntqq": false,
-    "_comment-ntqq": "用于切换旧版qq也将强制前台，默认支持ntqq且窗口强制前台",
-    "sleep_time": 2
+    "send_qq": {
+        "_info": "auto:自动寻找qq窗口,ntqq: 是否启用QQNT发送消息,activate: 是否激活前台窗口,sleep_time: 全局操作延迟时间(秒)",
+        "auto": true,
+        "ntqq": false,
+        "activate": false,
+        "sleep_time": 2
+    }
 }

--- a/config.json
+++ b/config.json
@@ -13,10 +13,11 @@
         }
     },
     "live": {
-        "sessdata": "9ff14338%2C1759584628%2C4e814%2A42CjAHa7g9KR2WWvwU9LQ4pDU6wvTikKtoYlgpaPCbSFcdRAswE3IF4-ksmkQkjH0UuqESVjlHZVJXR2JRM2kyLXUzSXltX25sRWdMU2JUQXE3TUs2UW83OTgzeTgxUnZ0b0Raa1pJdE9iX1Z3N2tuOUY5bnNkS1RXVnMyd21iNW05VGlzd2t6aHN3IIEC",
-        "room_display_id": "30690803",
-        "handle_list": ["響皇登基第二年"],
+        "sessdata": "",
+        "room_display_id": "",
+        "handle_list": [""],
         "class_list": ["TXGuiFoundation", "Chrome_WidgetWin_1"],
+        "_comment": "标题匹配和类名，修改后捕捉对应窗口即可发送消息与图片，非qq也将可用，默认回车，请将qq发送消息改为回车发送",
         "at_all": false,
         "sleep_config": {
             "_comment": "window_activate：激活窗口的延迟（秒）paste：粘贴文本或图片的延迟（秒）enter：按回车发送的延迟（秒）loop：循环间隔延迟（秒）",
@@ -27,5 +28,6 @@
         }
     },
     "ntqq": false,
+    "_comment-ntqq": "用于切换旧版qq也将强制前台，默认支持ntqq且窗口强制前台",
     "sleep_time": 2
 }

--- a/config.json
+++ b/config.json
@@ -1,16 +1,31 @@
 {
-    "bot":{
-        "sessdata":"", 
-        "uid":"",
+    "bot": {
+        "sessdata": "",
+        "uid": "",
         "handle_list": ["测试", "test", "BOT"],
-        "at_all":false
+        "class_list": ["TXGuiFoundation", "Chrome_WidgetWin_1"],
+        "at_all": false,
+        "sleep_config": {
+            "window_activate": 0.2,
+            "paste": 0.2,
+            "enter": 0.2,
+            "loop": 1
+        }
     },
-    "live":{
-        "sessdata":"", 
-        "room_display_id":"",
-        "handle_list": ["测试", "test", "BOT"],
-        "at_all":false
+    "live": {
+        "sessdata": "9ff14338%2C1759584628%2C4e814%2A42CjAHa7g9KR2WWvwU9LQ4pDU6wvTikKtoYlgpaPCbSFcdRAswE3IF4-ksmkQkjH0UuqESVjlHZVJXR2JRM2kyLXUzSXltX25sRWdMU2JUQXE3TUs2UW83OTgzeTgxUnZ0b0Raa1pJdE9iX1Z3N2tuOUY5bnNkS1RXVnMyd21iNW05VGlzd2t6aHN3IIEC",
+        "room_display_id": "30690803",
+        "handle_list": ["響皇登基第二年"],
+        "class_list": ["TXGuiFoundation", "Chrome_WidgetWin_1"],
+        "at_all": false,
+        "sleep_config": {
+            "_comment": "window_activate：激活窗口的延迟（秒）paste：粘贴文本或图片的延迟（秒）enter：按回车发送的延迟（秒）loop：循环间隔延迟（秒）",
+            "window_activate": 0.2,
+            "paste": 0.2,
+            "enter": 0.2,
+            "loop": 1
+        }
     },
-    "ntqq":false,
-    "sleep_time":2
+    "ntqq": false,
+    "sleep_time": 2
 }

--- a/config.json
+++ b/config.json
@@ -1,23 +1,21 @@
 {
     "bot": {
-        "_info": "sessdata:cookie,uid:UP主的UID,handle_list:窗口标题关键词列表, at_all:是否@所有人(全部类型)",
+        "_info": "sessdata:cookie, uid:UP主的UID, at_all:是否@所有人(全部类型)",
         "sessdata": "",
         "uid": "",
-        "handle_list": ["测试", "test", "BOT"],
         "at_all": false
     },
     "live": {
-        "_info": "sessdata:cookie,room_display_id:直播间ID,handle_list:窗口标题关键词列表, at_all:是否@所有人(仅开播通知生效)",
+        "_info": "sessdata:cookie, room_display_id:直播间ID, at_all:是否@所有人(仅开播通知生效)",
         "sessdata": "",
         "room_display_id": "",
-        "handle_list": ["测试", "test", "BOT"],
         "at_all": false
     },
     "send_qq": {
-        "_info": "auto:自动寻找qq窗口,ntqq: 是否启用QQNT发送消息,activate: 是否激活前台窗口,sleep_time: 全局操作延迟时间(秒)",
+        "_info": "auto:自动寻找qq窗口, ntqq:是否启用QQNT发送消息, handle_list:窗口标题关键词列表, sleep_time:全局操作延迟时间(秒)",
         "auto": true,
         "ntqq": false,
-        "activate": false,
+        "handle_list": ["测试", "test", "BOT"],
         "sleep_time": 2
     }
 }

--- a/logger.py
+++ b/logger.py
@@ -51,8 +51,10 @@ def setup_logger(filename):
     log_file = os.path.join(log_dir, f'{filename}_{date_str}.log')
     
     file_handler = DailyRotatingFileHandler(log_file, backupCount=10)
+    file_handler.setLevel(logging.DEBUG)  # 文件记录DEBUG及以上级别日志
     
     console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setLevel(logging.INFO)  # 控制台只输出INFO及以上级别日志
     
     formatter = logging.Formatter(
         '%(asctime)s - %(levelname)s - %(filename)s:%(lineno)d - %(message)s'
@@ -61,7 +63,7 @@ def setup_logger(filename):
     console_handler.setFormatter(formatter)
     
     logger = logging.getLogger()
-    logger.setLevel(logging.INFO)
+    logger.setLevel(logging.DEBUG)
     
     logger.addHandler(file_handler)
     logger.addHandler(console_handler)

--- a/send_qq.py
+++ b/send_qq.py
@@ -1,214 +1,266 @@
-from time import sleep
+import argparse
+import json
+import os
+import io
+import time
 import requests
-import win32con
 import win32gui
+import win32con
 import win32clipboard
-import win32com.client
 import win32api
 from PIL import Image
-import json
-import io
-import sys
-import argparse
-from logger import setup_logger
-from typing import Union
+import re
+import logging
+import glob
 
-logger = setup_logger(filename='send_qq')
+# ------------------ Logger ------------------
+logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger("send_qq")
 
-def parse_args():
-    """解析命令行参数"""
-    parser = argparse.ArgumentParser(description='发送消息至qq窗口的脚本模块')
-    parser.add_argument('-p', '--pic', dest='pic_path', type=str, default=None,
-                        help='传入图片的本地路径_default=None')
-    parser.add_argument('-t', '--text', dest='text', type=str, default=None,
-                        help='传入需要发送的内容_must')
-    parser.add_argument('-a', '--at_all', dest='at_all', type=int, default=1,
-                        help='是否强制@所有人，0为强制否，其他参数代表config为最高优先级_default=1')
-    return parser.parse_args()
+# ------------------ 命令行参数 ------------------
+parser = argparse.ArgumentParser(description="发送消息到QQ窗口")
+parser.add_argument('-t', '--text', required=True, help="发送的文本内容")
+parser.add_argument('-p', '--pic', default=None, help="图片URL")
+parser.add_argument('-c', '--config_type', default="live", choices=["bot","live"], help="配置段：bot/live")
+parser.add_argument('-a', '--at_all', type=int, choices=[0, 1], help="是否@全体成员 (0:否, 1:是)", default=None)
+parser.add_argument('--dry-run', action='store_true', help="只调试不实际发送")
+args = parser.parse_args()
 
-def send_to_window_ntqq(hwnd:int, text:str, at_all=False, pic_path=None,sleep_time:Union[int,float]=2):
-    """向指定NTQQ窗口发送消息（文本 + @全体）"""
-    win32gui.ShowWindow(hwnd, win32con.SW_RESTORE)  # 恢复窗口
-    win32gui.SetForegroundWindow(hwnd)  # 确保窗口在前台
-    sleep(sleep_time)
+# ------------------ 配置读取 ------------------
+with open("config.json", "r", encoding="utf-8") as f:
+    config = json.load(f)
 
-    # @全体
-    if at_all:
-        win32clipboard.OpenClipboard()
-        win32clipboard.EmptyClipboard()
-        win32clipboard.SetClipboardData(win32con.CF_UNICODETEXT, "@")
-        win32clipboard.CloseClipboard()
-        win32api.keybd_event(win32con.VK_CONTROL, 0, 0, 0)  # 按下Ctrl
-        win32api.keybd_event(ord('V'), 0, 0, 0)  # 按下V
-        win32api.keybd_event(ord('V'), 0, win32con.KEYEVENTF_KEYUP, 0)  # 释放V
-        win32api.keybd_event(win32con.VK_CONTROL, 0, win32con.KEYEVENTF_KEYUP, 0)
-        sleep(sleep_time)   #等待@符号加载
-        # 按下Enter键
-        win32api.keybd_event(win32con.VK_RETURN, 0, 0, 0)
-        # 释放Enter键
-        win32api.keybd_event(win32con.VK_RETURN, 0, win32con.KEYEVENTF_KEYUP, 0)
-        sleep(sleep_time)
+cfg = config[args.config_type]
+handle_list = cfg.get("handle_list", [])
+class_list = cfg.get("class_list", ["TXGuiFoundation", "Chrome_WidgetWin_1"])
+config_at_all = bool(cfg.get("at_all", False))
+sleep_config = cfg.get("sleep_config", {})
+ntqq = config.get("ntqq", False)  # 全局QQNT设置
+sleep_time = config.get("sleep_time", 2)  # 全局延迟设置
 
-    # 文本
-    win32clipboard.OpenClipboard()
-    win32clipboard.EmptyClipboard()
-    win32clipboard.SetClipboardData(win32con.CF_UNICODETEXT, text)
-    win32clipboard.CloseClipboard()
-    sleep(sleep_time)
+# 从sleep_config中获取具体延迟时间，如果没有则使用默认值
+window_activate_delay = sleep_config.get("window_activate", 0.2)
+paste_delay = sleep_config.get("paste", 0.2)
+enter_delay = sleep_config.get("enter", 0.2)
+loop_delay = sleep_config.get("loop", 1)
 
-    win32api.keybd_event(win32con.VK_CONTROL, 0, 0, 0)  # 按下Ctrl
-    win32api.keybd_event(ord('V'), 0, 0, 0)  # 按下V
-    win32api.keybd_event(ord('V'), 0, win32con.KEYEVENTF_KEYUP, 0)  # 释放V
-    win32api.keybd_event(win32con.VK_CONTROL, 0, win32con.KEYEVENTF_KEYUP, 0)
+if args.at_all is not None:
+    final_at_all = bool(args.at_all)
+else:
+    final_at_all = config_at_all
 
-    # 处理图片
-    if pic_path is not None:
-        # 下载图片
-        response = requests.get(pic_path, stream=True)
+logger.info(f"匹配窗口列表: {handle_list}, 类名列表: {class_list}, @所有人: {final_at_all}, QQNT模式: {ntqq}")
+logger.info(f"延迟配置: 激活{window_activate_delay}s, 粘贴{paste_delay}s, 回车{enter_delay}s, 循环{loop_delay}s")
+
+# ------------------ 文本解析 ------------------
+def decode_unicode_escapes(text):
+    text = re.sub(r'\\u([0-9a-fA-F]{4})', lambda m: chr(int(m.group(1),16)), text)
+    text = text.replace("\\n", "\n")
+    text = text.strip('"')
+    return text
+
+text = decode_unicode_escapes(args.text)
+logger.info(f"最终发送文本:\n{text}")
+
+# ------------------ 下载图片 ------------------
+filename = None
+if args.pic:
+    try:
+        # 从URL中提取文件名
+        url_parts = args.pic.split("/")
+        url_filename = url_parts[-1] if url_parts[-1] else url_parts[-2]
+        
+        # 确保有.jpg扩展名
+        if not url_filename.lower().endswith(('.jpg', '.jpeg', '.png', '.gif', '.bmp')):
+            url_filename += ".jpg"
+            
+        response = requests.get(args.pic, stream=True)
         response.raise_for_status()
-        filename = pic_path.split("/")[-1]
-        with open(filename, 'wb') as file:
-            for chunk in response.iter_content(chunk_size=8192):
-                file.write(chunk)
-        # 发送图片
-        image = Image.open(filename)
-        output = io.BytesIO()
-        image.convert("RGB").save(output, "BMP")
-        data = output.getvalue()[14:]
-        win32clipboard.OpenClipboard()
-        win32clipboard.EmptyClipboard()
-        win32clipboard.SetClipboardData(win32con.CF_DIB, data)
-        win32clipboard.CloseClipboard()
-        sleep(sleep_time)
-        win32api.keybd_event(win32con.VK_CONTROL, 0, 0, 0)  # 按下Ctrl
-        win32api.keybd_event(ord('V'), 0, 0, 0)  # 按下V
-        win32api.keybd_event(ord('V'), 0, win32con.KEYEVENTF_KEYUP, 0)  # 释放V
-        win32api.keybd_event(win32con.VK_CONTROL, 0, win32con.KEYEVENTF_KEYUP, 0)
+        filename = url_filename
+        with open(filename, "wb") as f:
+            for chunk in response.iter_content(8192):
+                f.write(chunk)
+        logger.info(f"图片下载成功: {filename}")
+    except Exception as e:
+        logger.error(f"图片下载失败: {e}")
+        filename = None
 
-    # 发送
-    sleep(sleep_time)
-    # 按下Enter键
-    win32api.keybd_event(win32con.VK_RETURN, 0, 0, 0)
-    # 释放Enter键
-    win32api.keybd_event(win32con.VK_RETURN, 0, win32con.KEYEVENTF_KEYUP, 0)
-    sleep(sleep_time)
-    print(f"✅ 已向窗口[{win32gui.GetWindowText(hwnd)}]发送消息")
+# ------------------ 窗口匹配 ------------------
+def enum_windows_callback(hwnd, hwnds):
+    if win32gui.IsWindowVisible(hwnd):
+        title = win32gui.GetWindowText(hwnd)
+        cls = win32gui.GetClassName(hwnd)
+        hwnds.append((hwnd, title, cls))
 
-def enum_target_windows_ntqq(target_titles:list):
-    """枚举NTQQ目标窗口（严格匹配标题）"""
-    result = []
-    def callback(hwnd, extra):
-        if win32gui.IsWindowVisible(hwnd):
-            title = win32gui.GetWindowText(hwnd).strip()
-            if title in target_titles:  # 精确匹配
-                result.append(hwnd)
-        return True
-    win32gui.EnumWindows(callback, None)
-    return result
+def find_target_windows(target_names, target_classes):
+    hwnds = []
+    win32gui.EnumWindows(enum_windows_callback, hwnds)
+    matched = []
+    for hwnd, title, cls in hwnds:
+        if cls not in target_classes:
+            continue
+        for name in target_names:
+            if name in title:
+                matched.append((hwnd, title, cls))
+                break
+    return matched
 
-def send_to_window_qq(handle:int, text:str, at_all=False, pic_path=None, sleep_time:Union[int,float]=2):
-    """向指定传统QQ窗口发送消息（文本 + @全体）"""
-    # 初始化Shell对象用于发送按键
-    shell = win32com.client.Dispatch("WScript.Shell")
-    win32gui.ShowWindow(handle, win32con.SW_RESTORE)  # 恢复窗口（如果处于最小化状态）
-    shell.SendKeys('%')  # 发送Alt键绕过Windows的前台权限限制
-    win32gui.ShowWindow(handle, win32con.SW_SHOW)  # 确保窗口显示在最前端
-    logger.info(f"找到窗口句柄: {handle}")
-    
-    if at_all:
-        # 处理@符号
-        win32clipboard.OpenClipboard()
-        win32clipboard.EmptyClipboard()
-        win32clipboard.SetClipboardData(win32con.CF_UNICODETEXT, "@")
-        win32clipboard.CloseClipboard()
-        win32gui.SendMessage(handle, 770, 0, 0)  # Ctrl+V
-        sleep(sleep_time)   # 等待@符号加载
-        win32gui.SendMessage(handle, win32con.WM_KEYDOWN, win32con.VK_RETURN, 0)
-        sleep(sleep_time)
-    
-    # 处理文本
-    win32clipboard.OpenClipboard()
-    win32clipboard.EmptyClipboard()
-    win32clipboard.SetClipboardData(win32con.CF_UNICODETEXT, text)
-    win32clipboard.CloseClipboard()
-    sleep(sleep_time)
-    win32gui.SendMessage(handle, 770, 0, 0)  # Ctrl+V
-    
-    # 处理图片
-    if pic_path is not None:
-        # 下载图片
-        response = requests.get(pic_path, stream=True)
-        response.raise_for_status()
-        filename = pic_path.split("/")[-1]
-        with open(filename, 'wb') as file:
-            for chunk in response.iter_content(chunk_size=8192):
-                file.write(chunk)
-                
-        # 发送图片
-        image = Image.open(filename)
-        output = io.BytesIO()
-        image.convert("RGB").save(output, "BMP")
-        data = output.getvalue()[14:]
-        win32clipboard.OpenClipboard()
-        win32clipboard.EmptyClipboard()
-        win32clipboard.SetClipboardData(win32con.CF_DIB, data)
-        win32clipboard.CloseClipboard()
-        sleep(sleep_time)
-        win32gui.SendMessage(handle, 770, 0, 0)  # Ctrl+V
-    
-    # 发送
-    sleep(sleep_time)
-    win32gui.SendMessage(handle, win32con.WM_KEYDOWN, win32con.VK_RETURN, 0)
-    logger.info("消息发送成功")
-    sleep(sleep_time)
+matched_windows = find_target_windows(handle_list, class_list)
+if not matched_windows:
+    logger.error("没有找到匹配的QQ聊天窗口")
+    exit(1)
+logger.info(f"找到 {len(matched_windows)} 个匹配窗口")
 
-args = parse_args()
-pic = args.pic_path
-at_all_must = args.at_all
-# 对文本参数进行反转义处理
-if args.text:
-    # 先还原转义序列，再解码
-    text = args.text.encode('utf-8').decode('unicode_escape')
-else:
-    text = None
-
-if text is None:
-    logger.error("请使用-t参数传入需要发送的内容")
-    sys.exit(1)
-
-
-# 从配置文件中读取配置
-with open('config.json', 'r', encoding='utf-8') as config_file:
-    config = json.load(config_file)
-
-sleep_time = config.get('sleep_time')
-
-handle_list= list(config['bot']['handle_list'])
-if at_all_must == 0:
-    at_all = False
-else:
-    at_all = bool(config['bot']['at_all'])
-
-# 检查是否使用NTQQ模式
-is_ntqq = bool(config.get('ntqq', False))
-
-if is_ntqq:
-    # NTQQ模式
-    hwnds = enum_target_windows_ntqq(handle_list)
-    if not hwnds:
-        print("❌ 未找到符合条件的窗口")
-        sys.exit(1)
-    else:
-        print(f"找到 {len(hwnds)} 个目标窗口")
-        for hwnd in hwnds:
-            send_to_window_ntqq(hwnd, text, at_all, pic,sleep_time)
-else:
-    # 传统QQ模式
-    for handles in handle_list:
-        handle = win32gui.FindWindow(None, handles) # 获取窗口句柄
-        if handle != 0:  # 确保窗口存在
-            send_to_window_qq(handle, text, at_all, pic,sleep_time)
+# ------------------ 激活窗口 ------------------
+def activate_window(hwnd, cls, is_ntqq):
+    try:
+        win32gui.ShowWindow(hwnd, win32con.SW_RESTORE)
+        if is_ntqq or cls == "Chrome_WidgetWin_1":
+            # QQNT 或配置为QQNT模式的窗口使用前台激活
+            win32gui.SetForegroundWindow(hwnd)
+            logger.info(f"使用前台激活模式 (QQNT/Chrome窗口)")
         else:
-            logger.warning(f"未找到窗口: {handles}")
+            # 旧版QQ使用后台模式
+            logger.info(f"使用后台模式 (旧版QQ)")
+        time.sleep(window_activate_delay)
+        return True
+    except Exception as e:
+        logger.error(f"窗口激活失败: {e}")
+        return False
 
-exit(0)
+# ------------------ 粘贴和发送 ------------------
+def paste_text_to_window(hwnd, text, is_ntqq):
+    """粘贴文本到窗口，根据模式选择前台或后台粘贴"""
+    try:
+        # 设置剪贴板
+        win32clipboard.OpenClipboard()
+        win32clipboard.EmptyClipboard()
+        win32clipboard.SetClipboardData(win32con.CF_UNICODETEXT, text)
+        win32clipboard.CloseClipboard()
+        
+        if is_ntqq:
+            # QQNT模式：前台粘贴
+            win32api.keybd_event(win32con.VK_CONTROL, 0, 0, 0)
+            win32api.keybd_event(0x56, 0, 0, 0)  # V
+            win32api.keybd_event(0x56, 0, win32con.KEYEVENTF_KEYUP, 0)
+            win32api.keybd_event(win32con.VK_CONTROL, 0, win32con.KEYEVENTF_KEYUP, 0)
+        else:
+            # 旧版QQ模式：后台发送消息
+            win32gui.SendMessage(hwnd, win32con.WM_PASTE, 0, 0)
+        
+        time.sleep(paste_delay)
+        return True
+    except Exception as e:
+        logger.error(f"文本粘贴失败: {e}")
+        return False
+
+def paste_image_to_window(hwnd, filename, is_ntqq):
+    """粘贴图片到窗口，根据模式选择前台或后台粘贴"""
+    try:
+        image = Image.open(filename)
+        output = io.BytesIO()
+        image.convert("RGB").save(output, "BMP")
+        data = output.getvalue()[14:]  # 去除BMP头
+        
+        # 设置剪贴板
+        win32clipboard.OpenClipboard()
+        win32clipboard.EmptyClipboard()
+        win32clipboard.SetClipboardData(win32con.CF_DIB, data)
+        win32clipboard.CloseClipboard()
+        
+        if is_ntqq:
+            # QQNT模式：前台粘贴
+            win32api.keybd_event(win32con.VK_CONTROL, 0, 0, 0)
+            win32api.keybd_event(0x56, 0, 0, 0)  # V
+            win32api.keybd_event(0x56, 0, win32con.KEYEVENTF_KEYUP, 0)
+            win32api.keybd_event(win32con.VK_CONTROL, 0, win32con.KEYEVENTF_KEYUP, 0)
+        else:
+            # 旧版QQ模式：后台发送消息
+            win32gui.SendMessage(hwnd, win32con.WM_PASTE, 0, 0)
+        
+        time.sleep(paste_delay)
+        return True
+    except Exception as e:
+        logger.error(f"图片粘贴失败: {e}")
+        return False
+
+def send_enter_to_window(hwnd, is_ntqq):
+    """发送回车键，根据模式选择前台或后台发送"""
+    try:
+        if is_ntqq:
+            # QQNT模式：前台发送
+            win32api.keybd_event(win32con.VK_RETURN, 0, 0, 0)
+            win32api.keybd_event(win32con.VK_RETURN, 0, win32con.KEYEVENTF_KEYUP, 0)
+        else:
+            # 旧版QQ模式：后台发送回车
+            win32gui.SendMessage(hwnd, win32con.WM_KEYDOWN, win32con.VK_RETURN, 0)
+            win32gui.SendMessage(hwnd, win32con.WM_KEYUP, win32con.VK_RETURN, 0)
+        
+        time.sleep(enter_delay)
+        return True
+    except Exception as e:
+        logger.error(f"发送回车失败: {e}")
+        return False
+
+# ------------------ 清理旧图片 ------------------
+def cleanup_old_images(keep_filename=None):
+    """清理旧的图片文件，保留当前使用的文件"""
+    image_extensions = ('*.jpg', '*.jpeg', '*.png', '*.gif', '*.bmp')
+    image_files = []
+    
+    for ext in image_extensions:
+        image_files.extend(glob.glob(ext))
+    
+    for file in image_files:
+        if keep_filename and file == keep_filename:
+            continue
+        try:
+            os.remove(file)
+            logger.info(f"已清理旧图片: {file}")
+        except Exception as e:
+            logger.debug(f"清理文件失败 {file}: {e}")
+
+# ------------------ 主流程 ------------------
+try:
+    for hwnd, title, cls in matched_windows:
+        logger.info(f"处理窗口: {title} (句柄: {hwnd}, 类名: {cls})")
+        
+        # 判断是否为QQNT模式
+        is_ntqq_mode = ntqq or cls == "Chrome_WidgetWin_1"
+        
+        if not activate_window(hwnd, cls, is_ntqq_mode):
+            logger.error("窗口激活失败，跳过此窗口")
+            continue
+
+        if args.dry_run:
+            logger.info("Dry-run模式：跳过实际发送")
+            continue
+
+        # @全体成员
+        if final_at_all:
+            paste_text_to_window(hwnd, "@所有人", is_ntqq_mode)
+            send_enter_to_window(hwnd, is_ntqq_mode)
+            time.sleep(loop_delay)
+
+        # 发送文本
+        paste_text_to_window(hwnd, text, is_ntqq_mode)
+
+        # 发送图片
+        if filename:
+            paste_image_to_window(hwnd, filename, is_ntqq_mode)
+
+        # 最终发送
+        send_enter_to_window(hwnd, is_ntqq_mode)
+        logger.info(f"消息已发送到窗口: {title}")
+        
+        # 窗口间延迟
+        time.sleep(sleep_time)
+
+except Exception as e:
+    logger.error(f"发送过程中出现错误: {e}")
+
+finally:
+    # 清理旧图片，保留当前使用的图片
+    cleanup_old_images(filename)
+    if filename:
+        logger.info(f"新图片 {filename} 已保留")

--- a/send_qq.py
+++ b/send_qq.py
@@ -9,9 +9,7 @@ import win32con
 import win32clipboard
 import win32api
 from PIL import Image
-import re
 from logger import setup_logger
-import glob
 from typing import Optional
 import argparse
 logger = setup_logger(filename='send_qq')
@@ -19,7 +17,7 @@ logger = setup_logger(filename='send_qq')
 class ArgsType(argparse.Namespace):
     text: str
     pic: Optional[str]
-    at_all: Optional[int]
+    at_all: int
     dry_run: bool
 parser = argparse.ArgumentParser(description="发送消息到QQ窗口")
 parser.add_argument('-t', '--text', required=True, help="发送的文本内容")
@@ -49,12 +47,10 @@ logger.info(f"匹配窗口列表: {handle_list}, 类名列表: {class_list}, @�
 
 # ------------------ 文本解析 ------------------
 # 对文本参数进行反转义处理
-if args.text:
-    # 先还原转义序列，再解码
-    text = args.text.encode('utf-8').decode('unicode_escape')
-else:
-    text = None
-logger.info(f"最终发送文本:\n{text}")
+# 先还原转义序列，再解码
+logger.debug(f"原始文本: {args.text}")
+text = args.text.encode('utf-8').decode('unicode_escape')
+logger.info(f"发送文本:\n{text}")
 
 # ------------------ 下载图片 ------------------
 image_data = None
@@ -187,23 +183,6 @@ def send_enter_to_window(hwnd, is_ntqq):
         logger.error(f"发送回车失败: {e}")
         return False
 
-# ------------------ 清理旧图片 ------------------
-def cleanup_old_images(keep_filename=None):
-    """清理旧的图片文件，保留当前使用的文件"""
-    image_extensions = ('*.jpg', '*.jpeg', '*.png', '*.gif', '*.bmp')
-    image_files = []
-    
-    for ext in image_extensions:
-        image_files.extend(glob.glob(ext))
-    
-    for file in image_files:
-        if keep_filename and file == keep_filename:
-            continue
-        try:
-            os.remove(file)
-            logger.info(f"已清理旧图片: {file}")
-        except Exception as e:
-            logger.debug(f"清理文件失败 {file}: {e}")
 
 class_list=  ["TXGuiFoundation", "Chrome_WidgetWin_1"]
 
@@ -241,6 +220,6 @@ try:
         
         # 窗口间延迟
         time.sleep(sleep_time)
-
 except Exception as e:
     logger.error(f"发送过程中出现错误: {e}")
+exit(0)


### PR DESCRIPTION
用于win，基于原项目[bilipy_bot](https://github.com/GEYUANwuqi/bilipy_bot)修改[send_qq.py](https://github.com/GEYUANwuqi/bilipy_bot/blob/main/send_qq.py)代码，

多平台兼容跨越可能性较低，支持修改类名匹配，加上原项目中的标题，通过win32gui和SetForegroundWindow实现窗口查找与唤醒，修改类名和标题匹配到窗口后就会向该窗口发送文本+图片，如果该窗口支持，例如浏览器，wx和word没有测试过，类名可以通过代码查找，或者直接使用python的win32库，直接叫到前台可能会觉得烦，但是这个对于qqnt版是必要的，因为win的安全机制不允许程序后台使用键盘或者发送消息等，窗口被最小化也能被唤醒，

后台发消息仅限qq怀旧版，可以在配置文件中修改为qqnt同版强制前台，会出现窗口大小和位置被重置，不能最小化窗口，否则消息无法发出，可能仅发送图片，作为开播通知qq，较为稳定，

很抱歉多次提交的pr都被意外关闭了，而且时间也比预定的要很晚（不太会使用github，不太能看懂英文，点错东西的可能性极大）如果您对以往的pr提交文件感兴趣可以在虚拟机中进行测试，bug可能会很多就是了，这次的代码中也有可能很多